### PR TITLE
Updated curl_response to handle multiple HTTP status codes in the respon...

### DIFF
--- a/lib/curl_response.php
+++ b/lib/curl_response.php
@@ -53,11 +53,11 @@ class CurlResponse {
         
         # Extract the version and status from the first header
         $version_and_status = array_shift($headers);
-        preg_match('#HTTP/(\d\.\d)\s(\d\d\d)\s(.*)#', $version_and_status, $matches);
-        $this->headers['Http-Version'] = $matches[1];
-        $this->headers['Status-Code'] = $matches[2];
-        $this->headers['Status'] = $matches[2].' '.$matches[3];
-        
+        preg_match_all('#HTTP/(\d\.\d)\s(\d\d\d)\s#', $version_and_status, $matches);
+        $this->headers['Http-Version'] = array_pop($matches[1]);
+        $this->headers['Status-Code'] = array_pop($matches[2]);
+        $this->headers['Status'] = array_pop($matches[0]);
+
         # Convert headers into an associative array
         foreach ($headers as $header) {
             preg_match('#(.*?)\:\s(.*)#', $header, $matches);


### PR DESCRIPTION
I've altered the curl_response to only return the final HTTP response detected as per RFC spec:

http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html

"A client MUST be prepared to accept one or more 1xx status responses prior to a regular response, even if the client does not expect a 100 (Continue) status message. Unexpected 1xx status responses MAY be ignored by a user agent."

Example response:

"HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Date: Tue, 19 Nov 2013 20:50:45 GMT
Server: Apache/2.2.14 (Ubuntu)
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
Pragma: no-cache
Content-Length: 12
Content-Type: application/json

{example: 1}"
