### PR TITLE
Updated curl_response to handle multiple HTTP status codes in the response

### DIFF
--- a/lib/curl_response.php
+++ b/lib/curl_response.php
@@ -8,21 +8,21 @@
  * @author Sean Huber <shuber@huberry.com>
 **/
 class CurlResponse {
-    
+
     /**
      * The body of the response without the headers block
      *
      * @var string
     **/
     public $body = '';
-    
+
     /**
      * An associative array containing the response's headers
      *
      * @var array
     **/
     public $headers = array();
-    
+
     /**
      * Accepts the result of a curl request as a string
      *
@@ -37,12 +37,12 @@ class CurlResponse {
     function __construct($response) {
         # Headers regex
         $pattern = '#HTTP/\d\.\d.*?$.*?\r\n\r\n#ims';
-        
+
         # Extract headers from response
         preg_match_all($pattern, $response, $matches);
         $headers_string = array_pop($matches[0]);
         $headers = explode("\r\n", str_replace("\r\n\r\n", '', $headers_string));
-        
+
         # Inlude all received headers in the $headers_string
         while (count($matches[0])) {
           $headers_string = array_pop($matches[0]).$headers_string;
@@ -50,13 +50,13 @@ class CurlResponse {
 
         # Remove all headers from the response body
         $this->body = str_replace($headers_string, '', $response);
-        
+
         # Extract the version and status from the first header
         $version_and_status = array_shift($headers);
-        preg_match_all('#HTTP/(\d\.\d)\s(\d\d\d)\s#', $version_and_status, $matches);
+        preg_match_all('#HTTP/(\d\.\d)\s((\d\d\d)\s((.*?)(?=HTTP)|.*))#', $version_and_status, $matches);
         $this->headers['Http-Version'] = array_pop($matches[1]);
-        $this->headers['Status-Code'] = array_pop($matches[2]);
-        $this->headers['Status'] = array_pop($matches[0]);
+        $this->headers['Status-Code'] = array_pop($matches[3]);
+        $this->headers['Status'] = array_pop($matches[2]);
 
         # Convert headers into an associative array
         foreach ($headers as $header) {
@@ -64,7 +64,7 @@ class CurlResponse {
             $this->headers[$matches[1]] = $matches[2];
         }
     }
-    
+
     /**
      * Returns the response body
      *
@@ -79,5 +79,5 @@ class CurlResponse {
     function __toString() {
         return $this->body;
     }
-    
+
 }

--- a/lib/curl_response.php
+++ b/lib/curl_response.php
@@ -53,11 +53,11 @@ class CurlResponse {
         
         # Extract the version and status from the first header
         $version_and_status = array_shift($headers);
-        preg_match('#HTTP/(\d\.\d)\s(\d\d\d)\s(.*)#', $version_and_status, $matches);
-        $this->headers['Http-Version'] = $matches[1];
-        $this->headers['Status-Code'] = $matches[2];
-        $this->headers['Status'] = $matches[2].' '.$matches[3];
-        
+        preg_match_all('#HTTP/(\d\.\d)\s(\d\d\d)\s#', $version_and_status, $matches);
+        $this->headers['Http-Version'] = array_pop($matches[1]);
+        $this->headers['Status-Code'] = array_pop($matches[2]);
+        $this->headers['Status'] = array_pop($matches[0]);
+
         # Convert headers into an associative array
         foreach ($headers as $header) {
             preg_match('#(.*?)\:\s(.*)#', $header, $matches);

--- a/test/unit/curl_response_multiple_codes_test.php
+++ b/test/unit/curl_response_multiple_codes_test.php
@@ -1,0 +1,25 @@
+<?php
+
+class CurlResponseMultipleCodesTest extends ztest\UnitTestCase {
+
+    function setup() {
+        $this->response = new CurlResponse(file_get_contents(__DIR__ . '/multiple_response_header.txt'));
+    }
+
+    function test_should_separate_response_headers_from_body() {
+        ensure(is_array($this->response->headers));
+        assert_matches('#^{example: 1}#', $this->response->body);
+    }
+
+    function test_should_set_status_headers() {
+        assert_equal(200, $this->response->headers['Status-Code']);
+        assert_equal('200 OK', $this->response->headers['Status']);
+    }
+
+    function test_should_return_response_body_when_calling_toString() {
+        ob_start();
+        echo $this->response;
+        assert_equal($this->response->body, ob_get_clean());
+    }
+
+}

--- a/test/unit/multiple_response_header.txt
+++ b/test/unit/multiple_response_header.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 100 Continue
+
+HTTP/1.1 200 OK
+Date: Tue, 19 Nov 2013 20:50:45 GMT
+Server: Apache/2.2.14 (Ubuntu)
+Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+Pragma: no-cache
+Content-Length: 95
+Content-Type: application/json
+
+{example: 1}


### PR DESCRIPTION
I've altered the curl_response to only return the final HTTP response detected as per RFC spec:

http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html

"A client MUST be prepared to accept one or more 1xx status responses prior to a regular response, even if the client does not expect a 100 (Continue) status message. Unexpected 1xx status responses MAY be ignored by a user agent."

Example response:

"HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Date: Tue, 19 Nov 2013 20:50:45 GMT
Server: Apache/2.2.14 (Ubuntu)
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
Pragma: no-cache
Content-Length: 12
Content-Type: application/json

{example: 1}"
