### PR TITLE
HTTP/2 compatibility

### DIFF
--- a/lib/curl_response.php
+++ b/lib/curl_response.php
@@ -53,10 +53,10 @@ class CurlResponse {
 
         # Extract the version and status from the first header
         $version_and_status = array_shift($headers);
-        preg_match_all('#HTTP/(\d\.\d)\s((\d\d\d)\s((.*?)(?=HTTP)|.*))#', $version_and_status, $matches);
+        preg_match_all('#HTTP/(\d(\.\d)?)\s((\d\d\d)\s((.*?)(?=HTTP)|.*))#', $version_and_status, $matches);
         $this->headers['Http-Version'] = array_pop($matches[1]);
-        $this->headers['Status-Code'] = array_pop($matches[3]);
-        $this->headers['Status'] = array_pop($matches[2]);
+        $this->headers['Status-Code'] = sizeof($matches) == 6 ? array_pop($matches[3]) : array_pop($matches[4]);
+        $this->headers['Status'] = sizeof($matches) == 6 ? array_pop($matches[2]) : array_pop($matches[3]);
 
         # Convert headers into an associative array
         foreach ($headers as $header) {

--- a/lib/curl_response.php
+++ b/lib/curl_response.php
@@ -36,7 +36,7 @@ class CurlResponse {
     **/
     function __construct($response) {
         # Headers regex
-        $pattern = '#HTTP/\d\.\d.*?$.*?\r\n\r\n#ims';
+        $pattern = '#HTTP/\d(\.\d)? .*?$.*?\r\n\r\n#ims';
 
         # Extract headers from response
         preg_match_all($pattern, $response, $matches);


### PR DESCRIPTION
The message format of an HTTP2 response starts with `HTTP/2 `, with no minor version defined. The regex to match the headers fails on this, as it expects a minor version to be set, from the time of `HTTP/1.0` and `HTTP/1.1`

This PR adjusts the regex and makes the minor version in the message optional.